### PR TITLE
fix(NextcloudConnectorService): new url in latest revision of nextcloud

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,92 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->name('*.php')
+    ->exclude('vendor')
+    ->exclude('cache')
+    ->exclude('node_modules');
+
+$rules = [
+    '@PSR12' => true, // Start with PSR-12 rules
+    '@Symfony' => true, // Add Symfony rules for more comprehensive formatting
+    // Additional custom rules
+    // https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/index.rst
+    'array_indentation' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+    ],
+    'yoda_style' => false,
+    'blank_line_after_namespace' => true,
+    'blank_line_after_opening_tag' => true,
+    'increment_style' => ['style' => 'post'],
+    'blank_line_before_statement' => [
+        'statements' => ['return'],
+    ],
+    'cast_spaces' => ['space' => 'none'],
+    'class_attributes_separation' => [
+        'elements' => ['method' => 'one'],
+    ],
+    'concat_space' => ['spacing' => 'one'],
+    'declare_equal_normalize' => ['space' => 'none'],
+    'function_declaration' => ['closure_function_spacing' => 'one'],
+    'include' => true,
+    'indentation_type' => true,
+    'lowercase_cast' => true,
+    'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+    'new_with_braces' => true,
+    'no_blank_lines_after_class_opening' => true,
+    'no_blank_lines_after_phpdoc' => true,
+    'no_empty_statement' => true,
+    'no_extra_blank_lines' => [
+        'tokens' => [
+            'extra',
+            'throw',
+            'use',
+            'use_trait',
+            'curly_brace_block',
+            'parenthesis_brace_block',
+            'square_brace_block',
+            'switch',
+            'case',
+            'default',
+        ],
+    ],
+    'no_leading_import_slash' => true,
+    'no_leading_namespace_whitespace' => true,
+    'no_mixed_echo_print' => ['use' => 'echo'],
+    'no_multiline_whitespace_around_double_arrow' => true,
+    'no_short_bool_cast' => true,
+    'no_singleline_whitespace_before_semicolons' => true,
+    'no_spaces_around_offset' => ['positions' => ['inside', 'outside']],
+    'no_trailing_comma_in_singleline_array' => true,
+    'no_trailing_whitespace' => true,
+    'no_trailing_whitespace_in_comment' => true,
+    'no_unused_imports' => true,
+    'no_whitespace_before_comma_in_array' => true,
+    'no_whitespace_in_blank_line' => true,
+    'normalize_index_brace' => true,
+    'object_operator_without_whitespace' => true,
+    'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    'semicolon_after_instruction' => true,
+    'short_scalar_cast' => true,
+    'single_blank_line_at_eof' => true,
+    'single_class_element_per_statement' => ['elements' => ['property']],
+    'single_import_per_statement' => true,
+    'single_line_after_imports' => true,
+    'single_quote' => true,
+    'space_after_semicolon' => ['remove_in_empty_for_expressions' => true],
+    'standardize_not_equals' => true,
+    'switch_case_semicolon_to_colon' => true,
+    'switch_case_space' => true,
+    'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+    'trim_array_spaces' => true,
+    'unary_operator_spaces' => true,
+    'whitespace_after_comma_in_array' => true,
+];
+
+return (new PhpCsFixer\Config())
+    ->setRules($rules)
+    ->setFinder($finder)
+    ->setUsingCache(false); // Adjust cache settings as needed

--- a/config.yaml
+++ b/config.yaml
@@ -5,15 +5,15 @@
 parameters:
   # parameters to connect to nextcloud instance
   nextcloudconnector:
-    servername: ''
-    username: ''
-    applicationPassword: ''
+    servername: ""
+    username: ""
+    applicationPassword: ""
   # for edit config action
   nextcloudconnector_editable_config_params:
     - nextcloudconnector:
-      - servername
-      - username
-      - applicationPassword
+        - servername
+        - username
+        - applicationPassword
 
 services:
   _defaults:
@@ -21,4 +21,6 @@ services:
     public: true
 
   YesWiki\Nextcloudconnector\Service\:
-    resource: 'services/*'
+    resource: "services/*"
+    exclude:
+      - "services/SabreDavClient.php"

--- a/services/NextcloudConnectorService.php
+++ b/services/NextcloudConnectorService.php
@@ -71,7 +71,7 @@ class NextcloudConnectorService
      */
     public function getFilenameFromId(string $fileId, bool $forced = false): array
     {
-        $cachefilename = self::CACHE_FOLDER . "/".self::CACHE_PREFIX."{$this->sanitizeFileName($this->servername)}-$fileId.json";
+        $cachefilename = self::CACHE_FOLDER . "/" . self::CACHE_PREFIX . "{$this->sanitizeFileName($this->servername)}-$fileId.json";
         if (!$forced && file_exists($cachefilename)) {
             $fileinfo = json_decode(file_get_contents($cachefilename), true);
             $filename = $fileinfo['filename'] ?? '';
@@ -79,7 +79,7 @@ class NextcloudConnectorService
         }
         if (empty($filename) || empty($dirname)) {
             $url = "{$this->servername}f/$fileId";
-            
+
             $fp_tmp = tmpfile();
             $fp_fullpath = stream_get_meta_data($fp_tmp)['uri'];
             $ch = curl_init($url);
@@ -102,16 +102,16 @@ class NextcloudConnectorService
                 }
             }
             if (!preg_match("/^\/apps\/files\/\?dir=([^&]+)(?:&openfile=$fileId)?&scrollto=([^&]+)(?:&openfile=$fileId)?\s*$/", $location, $matches)) {
-                throw new NextcloudException(_t('NEXTCLOUDCONNECTOR_NOT_POSSIBLE_FIND_FILEINFO', ['fileId'=>"$fileId"]));
+                throw new NextcloudException(_t('NEXTCLOUDCONNECTOR_NOT_POSSIBLE_FIND_FILEINFO', ['fileId' => "$fileId"]));
             }
             $filename = urldecode(preg_replace("/\s*$/", "", $matches[2]));
             $dirname = urldecode($matches[1]);
-            file_put_contents($cachefilename, json_encode(['filename'=>$filename,'dirname'=>$dirname]));
+            file_put_contents($cachefilename, json_encode(['filename' => $filename,'dirname' => $dirname]));
         }
         if (empty($filename) || empty($dirname)) {
-            throw new NextcloudException(_t('NEXTCLOUDCONNECTOR_NOT_POSSIBLE_FIND_FILEINFO', ['fileId'=>$fileId]));
+            throw new NextcloudException(_t('NEXTCLOUDCONNECTOR_NOT_POSSIBLE_FIND_FILEINFO', ['fileId' => $fileId]));
         }
-        return ['filename'=>$filename,'dirname'=>$dirname,'fileId'=>$fileId];
+        return ['filename' => $filename,'dirname' => $dirname,'fileId' => $fileId];
     }
 
     /**
@@ -136,7 +136,7 @@ class NextcloudConnectorService
                     ->add(new DateInterval("PT{$maxAge}S"))
                     ->diff(new DateTime())
                     ->invert == 0
-                    ) {
+                ) {
                     $attach->fmDelete($filedata['realname']);
                     $updatedFiles = $attach->fmGetFiles(true);
                     foreach ($updatedFiles as $newFData) {
@@ -167,7 +167,7 @@ class NextcloudConnectorService
                 } else {
                     $fData = $this->getFilenameFromId($fData['fileId'], true);
                     $this->updateFileIfNeeded($fData, $maxAge, true);
-                    
+
                     $attach->file = $fData['filename'];
                     $fullFileName = $attach->GetFullFilename(true);
                     if (!file_exists("files/$fullFileName")) {
@@ -180,7 +180,7 @@ class NextcloudConnectorService
                 $fullFileName = $attach->GetFullFilename(true);
                 file_put_contents($fullFileName, $fileContent);
             }
-            return preg_replace("/^".preg_quote($attach->GetUploadPath(), "/")."\//", "", $fullFileName);
+            return preg_replace("/^" . preg_quote($attach->GetUploadPath(), "/") . "\//", "", $fullFileName);
         }
         return $foundFiles[0]['realname'];
     }
@@ -188,34 +188,34 @@ class NextcloudConnectorService
     /**
      * @return SabreDavClient $sabreDavClient
      */
-    private function getSabreWebDavClient():SabreDavClient
+    private function getSabreWebDavClient(): SabreDavClient
     {
         $url = "{$this->servername}remote.php/dav";
         return new SabreDavClient([
             'baseUri' => $url,
             'userName' => $this->nextcloudparams['username'] ?? '',
-            'password' =>$this->nextcloudparams['applicationPassword'] ?? ''
+            'password' => $this->nextcloudparams['applicationPassword'] ?? ''
         ]);
     }
 
-        
+
     /**
      * sanitize file name
      * @param string $inputString
      * @return string $outputString
      */
-    private function sanitizeFileName(string $inputString):string
+    private function sanitizeFileName(string $inputString): string
     {
         return removeAccents(preg_replace('/--+/u', '-', preg_replace('/[[:punct:]]/', '-', $inputString)));
     }
 
-    protected function getAttach():attach
+    protected function getAttach(): attach
     {
         if (is_null($this->attach)) {
             if (!class_exists('attach')) {
                 include('tools/attach/libs/attach.lib.php');
             }
-            
+
             $this->attach = new attach($this->wiki);
         }
         return $this->attach;

--- a/services/SabreDavClient.php
+++ b/services/SabreDavClient.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the YesWiki Extension nextcloudconnector.
+ *
+ * Authors : see README.md file that was distributed with this source code.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace YesWiki\Nextcloudconnector\Service;
+
+use Sabre\DAV\Client;
+use Sabre\HTTP;
+
+class SabreDavClient extends Client
+{
+    /**
+     * Does a PROPFIND request.
+     *
+     * The list of requested properties must be specified as an array, in clark
+     * notation.
+     *
+     * The returned array will contain a list of filenames as keys, and
+     * properties as values.
+     *
+     * The properties array will contain the list of properties. Only properties
+     * that are actually returned from the server (without error) will be
+     * returned, anything else is discarded.
+     *
+     * Depth should be either 0 or 1. A depth of 1 will cause a request to be
+     * made to the server to also return all child resources.
+     *
+     * @param string $url
+     * @param int    $depth
+     *
+     * @return array
+     */
+    public function propFind($url, array $properties, $depth = 0)
+    {
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->formatOutput = true;
+        $root = $dom->createElementNS('DAV:', 'd:propfind');
+        $root->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:oc', 'http://owncloud.org/ns');
+        $root->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:nc', 'http://nextcloud.org/ns');
+        $root->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:ocs', 'http://open-collaboration-services.org/ns');
+        $root->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:ocm', 'http://open-cloud-mesh.org/ns');
+        $prop = $dom->createElement('d:prop');
+
+        foreach ($properties as $property) {
+            list(
+                $namespace,
+                $elementName
+            ) = \Sabre\Xml\Service::parseClarkNotation($property);
+
+            $namespace = is_string($namespace) ? $namespace : '';
+            switch ($namespace) {
+                case 'DAV:':
+                    $element = $dom->createElement('d:' . $elementName);
+                    break;
+                case 'oc:':
+                case 'http://owncloud.org/ns:':
+                    $element = $dom->createElement('oc:' . $elementName);
+                    break;
+                case 'nc:':
+                case 'http://nextcloud.org/ns:':
+                    $element = $dom->createElement('nc:' . $elementName);
+                    break;
+                case 'ocs:':
+                case 'http://open-collaboration-services.org/ns:':
+                    $element = $dom->createElement('ocs:' . $elementName);
+                    break;
+                case 'ocm:':
+                case 'http://open-cloud-mesh.org/ns:':
+                    $element = $dom->createElement('ocm:' . $elementName);
+                    break;
+
+                default:
+                    $element = $dom->createElementNS($namespace, 'x:' . $elementName);
+                    break;
+            }
+
+            $prop->appendChild($element);
+        }
+
+        $dom->appendChild($root)->appendChild($prop);
+        $body = $dom->saveXML();
+
+        $url = $this->getAbsoluteUrl($url);
+
+        $request = new HTTP\Request('PROPFIND', $url, [
+            'Depth' => $depth,
+            'Content-Type' => 'application/xml',
+        ], $body);
+
+        $response = $this->send($request);
+
+        if ((int)$response->getStatus() >= 400) {
+            throw new HTTP\ClientHttpException($response);
+        }
+
+        $result = $this->parseMultiStatus($response->getBodyAsString());
+
+        // If depth was 0, we only return the top item
+        if (0 === $depth) {
+            reset($result);
+            $result = current($result);
+
+            return isset($result[200]) ? $result[200] : [];
+        }
+
+        $newResult = [];
+        foreach ($result as $href => $statusList) {
+            $newResult[$href] = isset($statusList[200]) ? $statusList[200] : [];
+        }
+
+        return $newResult;
+    }
+}


### PR DESCRIPTION
**Context**:
 - on some Nextcloud server with latest revision, the url's redirection when using file sharing's link, could have a new format.
 - this new format could not work to extract fileName

**What do the PR**
 - refactor (auto format PSR) (and add config file)
 - refactor `NextcloudConnectorService` split functions in small ones
 - use `PROPFIND` on folder to find the fileName associated to `fileId`
 - extend and improve `Sabre\DAV\Client` to be able to support `oc` namespace for `PROPFIND`

_Think to create a tag after merging to generate a new revision_