### PR TITLE
fix(NextcloudConnectorService): fileUrl replace space by %20 

### DIFF
--- a/services/NextcloudConnectorService.php
+++ b/services/NextcloudConnectorService.php
@@ -193,7 +193,12 @@ class NextcloudConnectorService
 
         if (empty($foundFiles)) {
             $sabreWebDavClient = $this->getSabreWebDavClient();
-            $fileUrl = "{$this->servername}remote.php/dav/files/{$this->nextcloudparams['username']}{$fData['dirname']}/{$fData['filename']}";
+            $fileUrl = "{$this->servername}remote.php/dav/files/"
+                // use `rawurlencode` to convert space as %20
+                . rawurlencode($this->nextcloudparams['username'])
+                . $fData['dirname']
+                . '/'
+                . rawurlencode($fData['filename']);
             // request($method, $url = '', $body = null, array $headers = [])
             $fileResponse = $sabreWebDavClient->request('GET', $fileUrl);
             if (empty($fileResponse['body']) || empty($fileResponse['statusCode']) || $fileResponse['statusCode'] != 200) {


### PR DESCRIPTION
**Objective**
Fix trouble with space in filenames.

**Context**
Using a fileId linked to a filename with a space create an error.

**What the new commits do**
Only using `rawurlencode` to be sure to encode space as `%20` as `SabreDav` requires.

**How to test**
put in a page `{{nextcloudconnectorattach desc="description of file" displaypdf="0" filetype="pdf" fileurl="https://example.com/f/123456"}}` linked to a file with space in filename

ping @mrflos 
